### PR TITLE
Add a button to adjust the brightness and exposure of the image

### DIFF
--- a/public/config.js.example
+++ b/public/config.js.example
@@ -22,6 +22,7 @@ const config = {
   ENABLE_PARCEL: false,
   ENABLE_POINTER: false,
   ENABLE_FOOTPRINT: false,
+  ENABLE_EXPOSURE: false,
 
   DOWNLOAD_TYPE: 'default'
 }

--- a/src/components/advanced-viewport.js
+++ b/src/components/advanced-viewport.js
@@ -1,6 +1,7 @@
 import { SkraaFotoViewport } from './viewport.js' 
 import { defaults as defaultInteractions } from 'ol/interaction'
 import { addViewSyncViewportTrigger, getViewSyncViewportListener } from '../modules/sync-view'
+import { SkraaFotoExposureTool } from './map-tool-exposure.js'
 import { SkraaFotoDownloadTool } from '../components/map-tool-download.js'
 import { CenterTool } from './map-tool-center.js'
 import { MeasureWidthTool } from './map-tool-measure-width.js'
@@ -11,6 +12,7 @@ import FullScreen from 'ol/control/FullScreen'
 import { configuration } from '../modules/configuration.js'
 
 
+customElements.define('skraafoto-exposure-tool', SkraaFotoExposureTool)
 customElements.define('skraafoto-download-tool', SkraaFotoDownloadTool)
 
 /**
@@ -34,7 +36,7 @@ export class SkraaFotoAdvancedViewport extends SkraaFotoViewport {
   // mousepos = new MousePosition() // For debugging
   date_selector_element
   // styles
-  adv_styles = `
+  adv_styles = /*css*/`
     .ol-viewport canvas {
       cursor: crosshair;
     }
@@ -86,8 +88,8 @@ export class SkraaFotoAdvancedViewport extends SkraaFotoViewport {
       width: 3.5rem !important;
     }
     
-    /* Info tool */
-    .sf-info-btn {
+    /* Info tool, exposure tool */
+    .sf-info-btn, .exposure-btn {
       border-radius: 0;
     }
 
@@ -127,7 +129,7 @@ export class SkraaFotoAdvancedViewport extends SkraaFotoViewport {
 
     }
   `
-  adv_template = `
+  adv_template = /*html*/`
     <style>
       ${ this.adv_styles }
     </style>
@@ -138,7 +140,7 @@ export class SkraaFotoAdvancedViewport extends SkraaFotoViewport {
         <hr>
         <button class="btn-width-measure ds-icon-map-icon-ruler" title="Mål afstand"></button>
         <button class="btn-height-measure ds-icon-map-icon-ruler" title="Mål højde"></button>
-        <skraafoto-info-box></skraafoto-info-box>
+        <skraafoto-info-box id="info-btn"></skraafoto-info-box>
         <skraafoto-download-tool></skraafoto-download-tool>
       </div>
     </nav>
@@ -165,6 +167,13 @@ export class SkraaFotoAdvancedViewport extends SkraaFotoViewport {
     div.innerHTML = this.adv_template
     this.shadowRoot.append(div)
 
+    // Add button to adjust brightness to the dom if enabled
+    if (configuration.ENABLE_EXPOSURE) {
+      const button_group = this.shadowRoot.querySelector('.ds-button-group')
+      const info_button = this.shadowRoot.querySelector('#info-btn')
+      button_group.insertBefore(document.createElement('skraafoto-exposure-tool'), info_button)
+    }
+
     // Refer DOM elements for later use
     this.date_selector_element = this.shadowRoot.querySelector('skraafoto-date-selector')
   }
@@ -172,6 +181,9 @@ export class SkraaFotoAdvancedViewport extends SkraaFotoViewport {
   updatePlugins() {
     super.updatePlugins()
     this.updateDateSelector(this.coord_world, this.item.id, this.item.properties.direction)
+    if (configuration.ENABLE_EXPOSURE) {
+      this.shadowRoot.querySelector('skraafoto-exposure-tool').setContextTarget = this
+    }
     this.shadowRoot.querySelector('skraafoto-download-tool').setContextTarget = this
     this.shadowRoot.querySelector('skraafoto-info-box').setItem = this.item
   }

--- a/src/components/map-tool-exposure.js
+++ b/src/components/map-tool-exposure.js
@@ -1,0 +1,82 @@
+import WebGLTileLayer from 'ol/layer/WebGLTile'
+
+/**
+ * Web component that enables user to change the exposure and brightness of the current image.
+ */
+export class SkraaFotoExposureTool extends HTMLElement {
+
+  // properties
+  button_element
+  viewport
+  variables
+
+  // setters
+  set setContextTarget(viewport) {
+    this.viewport = viewport
+    this.addStyleToLayer()
+  }
+
+  constructor() {
+    super()
+  }
+
+  // Methods
+
+  createDOM() {
+    // Add tool button to DOM
+    this.button_element = document.createElement('button')
+    this.button_element.className = 'exposure-btn ds-icon-sider-icon-lab'
+    this.button_element.title = 'Ændr lysstyrke'
+    this.append(this.button_element)
+  }
+  
+  /**
+   * Cycles the exposure
+   */
+  cycleExposure() {
+    this.addStyleToLayer()
+    this.variables.brightness += 0.25
+    if (this.variables.brightness > 0.75) {
+      this.variables.brightness = -0.75
+    }
+    this.variables.exposure = -0.5 * this.variables.brightness
+    console.log(`Brightness: ${ this.variables.brightness }, Exposure: ${ this.variables.exposure }`)
+    this.viewport.map.render()
+    this.button_element.blur()
+  }
+
+  addStyleToLayer() {
+    if (this.variables) { // style layer has already been added
+      return
+    }
+    const layers = this.viewport.map.getLayers().getArray()
+    const layer = layers.find(l => {
+      return l instanceof WebGLTileLayer
+    })
+    if (layer) {
+      this.variables = {
+        exposure: 0,
+        brightness: 0
+      }
+      layer.setStyle({
+        exposure: ['var', 'exposure'],
+        brightness: ['var', 'brightness'],
+        variables: this.variables
+      })
+    }
+  }
+
+
+  // Lifecycle callbacks
+
+  connectedCallback() {
+    this.createDOM()
+
+    this.button_element.addEventListener('click', () => {
+      this.cycleExposure()
+    })
+  }
+}
+
+// This is how to initialize the custom element
+// customElements.define('skraafoto-exposure-tool', SkraaFotoExposureTool)

--- a/src/components/map-tool-exposure.js
+++ b/src/components/map-tool-exposure.js
@@ -40,7 +40,6 @@ export class SkraaFotoExposureTool extends HTMLElement {
       this.variables.brightness = -0.75
     }
     this.variables.exposure = -0.5 * this.variables.brightness
-    console.log(`Brightness: ${ this.variables.brightness }, Exposure: ${ this.variables.exposure }`)
     this.viewport.map.render()
     this.button_element.blur()
   }

--- a/src/components/map-tool-exposure.js
+++ b/src/components/map-tool-exposure.js
@@ -8,7 +8,10 @@ export class SkraaFotoExposureTool extends HTMLElement {
   // properties
   button_element
   viewport
-  variables
+  variables = {
+    exposure: 0,
+    brightness: 0
+  }
 
   // setters
   set setContextTarget(viewport) {
@@ -34,7 +37,6 @@ export class SkraaFotoExposureTool extends HTMLElement {
    * Cycles the exposure
    */
   cycleExposure() {
-    this.addStyleToLayer()
     this.variables.brightness += 0.25
     if (this.variables.brightness > 0.75) {
       this.variables.brightness = -0.75
@@ -45,18 +47,11 @@ export class SkraaFotoExposureTool extends HTMLElement {
   }
 
   addStyleToLayer() {
-    if (this.variables) { // style layer has already been added
-      return
-    }
     const layers = this.viewport.map.getLayers().getArray()
     const layer = layers.find(l => {
       return l instanceof WebGLTileLayer
     })
     if (layer) {
-      this.variables = {
-        exposure: 0,
-        brightness: 0
-      }
       layer.setStyle({
         exposure: ['var', 'exposure'],
         brightness: ['var', 'brightness'],

--- a/src/components/map-tool-exposure.js
+++ b/src/components/map-tool-exposure.js
@@ -1,4 +1,5 @@
 import WebGLTileLayer from 'ol/layer/WebGLTile'
+import { configuration } from '../modules/configuration'
 
 /**
  * Web component that enables user to change the exposure and brightness of the current image.
@@ -8,10 +9,9 @@ export class SkraaFotoExposureTool extends HTMLElement {
   // properties
   button_element
   viewport
-  variables = {
-    exposure: 0,
-    brightness: 0
-  }
+  exposure_index = 0
+  variables = {}
+
 
   // setters
   set setContextTarget(viewport) {
@@ -21,6 +21,7 @@ export class SkraaFotoExposureTool extends HTMLElement {
 
   constructor() {
     super()
+    this.copySettingsToVariables(configuration.EXPOSURE_SETTINGS[this.exposure_index])
   }
 
   // Methods
@@ -32,16 +33,25 @@ export class SkraaFotoExposureTool extends HTMLElement {
     this.button_element.title = 'Ændr lysstyrke'
     this.append(this.button_element)
   }
+
+  copySettingsToVariables(settings) {
+    this.variables.exposure = settings.exposure
+    this.variables.brightness = settings.brightness
+    this.variables.contrast = settings.contrast
+    this.variables.saturation = settings.saturation
+  }
   
   /**
    * Cycles the exposure
    */
   cycleExposure() {
-    this.variables.brightness += 0.25
-    if (this.variables.brightness > 0.75) {
-      this.variables.brightness = -0.75
+    this.exposure_index += 1
+    if (this.exposure_index >= configuration.EXPOSURE_SETTINGS.length) {
+      this.exposure_index = 0
     }
-    this.variables.exposure = -0.5 * this.variables.brightness
+    const new_vars = configuration.EXPOSURE_SETTINGS[this.exposure_index]
+    this.copySettingsToVariables(configuration.EXPOSURE_SETTINGS[this.exposure_index])
+    console.log(this.variables)
     this.viewport.map.render()
     this.button_element.blur()
   }
@@ -55,6 +65,8 @@ export class SkraaFotoExposureTool extends HTMLElement {
       layer.setStyle({
         exposure: ['var', 'exposure'],
         brightness: ['var', 'brightness'],
+        contrast: ['var', 'contrast'],
+        saturation: ['var', 'saturation'],
         variables: this.variables
       })
     }

--- a/src/index.css
+++ b/src/index.css
@@ -14,5 +14,6 @@
 @import "@dataforsyningen/icons/css/icon-fullscreen.css";
 @import "@dataforsyningen/icons/css/icon-question.css";
 @import "@dataforsyningen/icons/css/icon-print.css";
+@import "@dataforsyningen/icons/css/sider-icon-lab.css"; /* Temp exposure icon, remove when new one is added */
 @import "./styles/layout.css";
 @import "./styles/header.css";

--- a/src/modules/configuration.js
+++ b/src/modules/configuration.js
@@ -27,7 +27,41 @@ let configuration = {
   MIN_ZOOM: 0, // the minimum zoom for skraafotos.
 
   SITEIMPROVE_SCRIPT: '',
-  DOWNLOAD_TYPE: 'default' // 'default' | 'currentview'
+  DOWNLOAD_TYPE: 'default', // 'default' | 'currentview'
+
+  // options for lighting to cycle through when clicking the light button
+  EXPOSURE_SETTINGS: [
+    {
+      exposure: 0,
+      brightness: 0,
+      contrast: 0,
+      saturation: 0
+    },
+    {
+      exposure: 0.4,
+      brightness: 0,
+      contrast: -0.4,
+      saturation: 0
+    },
+    {
+      exposure: 0.4,
+      brightness: 0,
+      contrast: 0,
+      saturation: 0
+    },
+    {
+      exposure: -0.6,
+      brightness: 0,
+      contrast: -0.4,
+      saturation: 0
+    },
+    {
+      exposure: -0.6,
+      brightness: 0,
+      contrast: -0.2,
+      saturation: 0
+    }
+  ]
 }
 
 // We assume a global variable `config` has been declared


### PR DESCRIPTION
- Needs to have a new Icon added at some point.
- Currently adjusting brightness in steps of .25 from -0.75 to .75 while exposure is set to -0.5 * brightness. Can be adjusted later as needed.