### PR TITLE
Fixes issue with syncronized centering 

### DIFF
--- a/src/components/viewport.js
+++ b/src/components/viewport.js
@@ -388,7 +388,6 @@ export class SkraaFotoViewport extends HTMLElement {
 
   /** Handler to update the relevant parts of the image map when an item is updated */
   async update_viewport_function() {
-    console.log('updating viewport, v, m', store.state.view.center, store.state.marker.center)
     this.toggleMode('center')
     this.item = store.state.viewports[this.dataset.index].item
     // Recalculates this.coord_world and this.coord_image
@@ -502,7 +501,6 @@ export class SkraaFotoViewport extends HTMLElement {
     * could lead to some big inaccuracies when calculating the zoom center.
     */
     if (!this.coord_world) {
-      console.log('no coord_world')
       return
     }
     const world_center = image2world(this.item, center[0], center[1], this.coord_world[2])

--- a/src/modules/sync-view.js
+++ b/src/modules/sync-view.js
@@ -2,46 +2,9 @@
  * @module
  */
 
-import { getZ, image2world, getImageXY } from '@dataforsyningen/saul'
+import { getZ, getImageXY } from '@dataforsyningen/saul'
 import { configuration } from './configuration'
 import store from '../store'
-
-/**
- * Adds a view sync trigger to the viewport.
- * @param {*} viewport The viewport.
- */
-function addViewSyncViewportTrigger(viewport) {
-  viewport.map.on('moveend', () => {
-    if (!viewport.sync) {
-      viewport.sync = true
-      return
-    }
-    viewport.self_sync = false
-    const view = viewport.map.getView()
-    const center = view.getCenter()
-    const world_zoom = viewport.toImageZoom(view.getZoom())
-    /* Note that we use the coord_world Z value here as we have no way to get the Z value based on the image
-    * coordinates. This means that the world coordinate we calculate will not be exact as the elevation can
-    * vary. If there are big differences in elevation between the selected center and the zoom center this
-    * could lead to some big inaccuracies when calculating the zoom center.
-    */
-    if (!viewport.coord_world) {
-      return
-    }
-    const world_center = image2world(viewport.item, center[0], center[1], viewport.coord_world[2])
-    getZ(world_center[0], world_center[1], configuration).then(z => {
-      store.state.marker = {
-        center: store.state.marker.center,
-        kote: z
-      }
-      store.dispatch('updateView', {
-        center: world_center,
-        kote: z,
-        zoom: world_zoom
-      })
-    })
-  })
-}
 
 /**
  * Gets a function for updating the viewport to be synchronized with other viewports.
@@ -135,7 +98,6 @@ function getViewSyncMapListener(viewport, map, always_sync = true) {
 }
 
 export {
-  addViewSyncViewportTrigger,
   getViewSyncViewportListener,
   addViewSyncMapTrigger,
   getViewSyncMapListener


### PR DESCRIPTION
`update_viewport_function` and `update_marker_function` were sharing a method that calculated the new image coordinates for the view. I've split up the functionality so that each function calculates different coordinates for view and marker.