### PR TITLE
Fix conflicting shortkeys

### DIFF
--- a/src/modules/listeners.js
+++ b/src/modules/listeners.js
@@ -30,10 +30,11 @@ function shiftItemTime(direction) {
 }
 
 function keyDownHandler(event) {
-  const isShiftKeyPressed = event.shiftKey;
-  const isViewport = event.target.tagName === 'SKRAAFOTO-VIEWPORT'
 
-  if (isShiftKeyPressed && !isViewport) {
+  const isShiftPressed = event.shiftKey
+  const isArrowKeyPressed = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)
+
+  if (isShiftPressed && isArrowKeyPressed) {
     event.preventDefault()
 
     switch (event.key) {
@@ -63,7 +64,7 @@ function setupListeners() {
   })
 
   document.addEventListener('loaderror', function (ev) {
-    console.error('Network error: ', ev.details);
+    console.error('Network error: ', ev.details)
     alert('Der var et problem med at hente data fra serveren.')
   })
 


### PR DESCRIPTION
This fixes the SHIFT+ARROWKEY shortkey feature so that it does not interfere with native features such as:
* SHIFT+TAB
* Using SHIFT to write uppercase letters in the search field

Fixes #188

Big thanks to @thomasclausen for pointing out the issue and writing the first solution draft.
