### PR TITLE
Token parameter fix

### DIFF
--- a/src/modules/configuration.js
+++ b/src/modules/configuration.js
@@ -119,7 +119,7 @@ if (urlParams.get('api') === 'test') {
 }
 // Checks if a custom API token is available from URL params or localstorage
 if (configuration.ENABLE_CUSTOM_TOKEN) {
-  const urlToken = urlParams.get('token')
+  const urlToken = urlParams.get('stactoken')
   const localToken = localStorage.getItem('skraafoto_stac_token')
   if (urlToken) {
     configuration.API_STAC_TOKEN = urlToken

--- a/src/modules/url-sanitize.js
+++ b/src/modules/url-sanitize.js
@@ -175,7 +175,6 @@ function removeUnusedCoordParams(params) {
 function removeUnusedParams(params) {
   params.delete('width')
   params.delete('mode')
-  params.delete('token')
   params.delete('project')
 }
 

--- a/test/e2e/centering.spec.js
+++ b/test/e2e/centering.spec.js
@@ -14,7 +14,7 @@ test('Change position when clicking in the viewport', async ({ page }) => {
   await expect(page.locator('css=skraafoto-viewport')).toContainText('koordinat 722119 Ø, 6178801 N set fra nord.')
   await expect(page.getByTitle('Billede af området omkring koordinat 722119 Ø, 6178801 N set fra øst.')).toBeDefined()
 
-  const centerTool = await page.getByTitle('Aktivér sigtekorn')
+  const centerTool = await page.getByTitle('Vælg en ny position')
   if (centerTool) {
     await centerTool.click()
     await page.mouse.click(200,200)

--- a/test/e2e/navigation.spec.js
+++ b/test/e2e/navigation.spec.js
@@ -15,7 +15,7 @@ test('Navigate to help page', async ({ page }) => {
 })
 
 test('Change to singleview', async ({ page }) => {
-  await page.getByTitle('Vis ét stort billede').click()
+  await page.getByTitle('Singleview').click()
   await page.waitForLoadState('networkidle')
   const skraafotoViewports = await page.evaluate(() => {
     return document.querySelectorAll('skraafoto-viewport').length
@@ -24,7 +24,7 @@ test('Change to singleview', async ({ page }) => {
 })
 
 test('Change to twinview', async ({ page }) => {
-  await page.getByTitle('Vis 2 store billeder').click()
+  await page.getByTitle('Twinview').click()
   await page.waitForLoadState('networkidle')
   const skraafotoViewports = await page.evaluate(() => {
     return document.querySelectorAll('skraafoto-viewport').length

--- a/test/e2e/navigation.spec.js
+++ b/test/e2e/navigation.spec.js
@@ -6,15 +6,16 @@ test.beforeEach(async ({ page }) => {
   await page.evaluate((conf) => {
     localStorage.setItem(conf.LOCAL_STORAGE_FIRST_TIME_VISITOR_KEY, false)
   }, configuration)
-  await page.goto('/')
 })
 
 test('Navigate to help page', async ({ page }) => {
+  await page.goto('/')
   await page.getByTitle('Information om Skråfoto').click()
   await expect(page.getByText('Information om Skråfoto')).toBeVisible()
 })
 
 test('Change to singleview', async ({ page }) => {
+  await page.goto('/')
   await page.getByTitle('Singleview').click()
   await page.waitForLoadState('networkidle')
   const skraafotoViewports = await page.evaluate(() => {
@@ -24,6 +25,7 @@ test('Change to singleview', async ({ page }) => {
 })
 
 test('Change to twinview', async ({ page }) => {
+  await page.goto('/')
   await page.getByTitle('Twinview').click()
   await page.waitForLoadState('networkidle')
   const skraafotoViewports = await page.evaluate(() => {
@@ -32,21 +34,21 @@ test('Change to twinview', async ({ page }) => {
   await expect(skraafotoViewports).toEqual(2)
 })
 
-test('Change orientation to west', async ({ page }) => {
+test.slow('Change orientation to west', async ({ page }) => {
   await page.goto('/?item=2023_83_29_2_0022_00002831', { waitUntil: 'networkidle' })
   await page.getByTitle('Vis mod vest').click()
   await page.waitForLoadState('networkidle')
   await expect(page.locator('css=skraafoto-viewport')).toContainText('Billede af området omkring koordinat 534893 Ø, 6173611 N set fra vest.')
 })
 
-test('Change orientation to nadir', async ({ page }) => {
+test.slow('Change orientation to nadir', async ({ page }) => {
   await page.goto('/?item=2023_83_29_2_0022_00002831', { waitUntil: 'networkidle' })
   await page.getByTitle('Vis fra top').click()
   await page.waitForLoadState('networkidle')
   await expect(page.locator('css=skraafoto-viewport')).toContainText('Billede af området omkring koordinat 534893 Ø, 6173611 N set fra top.')
 })
 
-test('Select map view', async ({ page }) => {
+test.slow('Select map view', async ({ page }) => {
   await page.goto('/?item=2023_83_29_2_0022_00002831', { waitUntil: 'networkidle' })
   await page.getByTitle('Skift til kortvisning').click()
   await page.waitForLoadState('networkidle')


### PR DESCRIPTION
Since `token` is used as an URL query parameter by another party, we rename our own custom token setting to `stactoken` in the URL.