### PR TITLE
test: updated e2e test to specify year such that validity does not depend on config

### DIFF
--- a/test/e2e/url.spec.js
+++ b/test/e2e/url.spec.js
@@ -14,13 +14,13 @@ test('Load viewer with center in WGS84 x/y format', async ({ page }) => {
 
 test('Load viewer with "center" url parameter (EPSG:25832)', async ({ page }) => {
   // Go to page and check that it renders in the correct position
-  await page.goto('/?center=726302,6096616', { waitUntil: 'networkidle' })
+  await page.goto('/?center=726302,6096616&year=2023', { waitUntil: 'networkidle' })
   await expect(page.locator('#viewport-1')).toContainText('Billede af området omkring koordinat 726302 Ø, 6096616 N set fra syd.')
 })
 
 test('Load viewer with center in EPSG:25832 x/y format', async ({ page }) => {
   // Go to page and check that it renders in the correct position
-  await page.goto('/?x=726302&y=6096616', { waitUntil: 'networkidle' })
+  await page.goto('/?x=726302&y=6096616&year=2023', { waitUntil: 'networkidle' })
   await expect(page.locator('#viewport-1')).toContainText('Billede af området omkring koordinat 726302 Ø, 6096616 N set fra syd.')
 })
 


### PR DESCRIPTION
# Description

Some e2e tests test for the existence of certain coordinates, such as /?center=726302,6096616
However, at current, websites configured with 2025 data do not have available data for this coordinate resulting in a failing test not reliant on the website. Hence, the test has been specified for a dataset where this data is available, 2023.